### PR TITLE
fix: module imports.

### DIFF
--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the module."""
 __name__ = 'paperscraper'
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 import logging
 import os

--- a/paperscraper/arxiv/arxiv.py
+++ b/paperscraper/arxiv/arxiv.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from typing import List, Union
 
 import arxiv
-from paperscraper.arxiv.utils import get_query_from_keywords
-from paperscraper.utils import dump_papers
+from .utils import get_query_from_keywords
+from ..utils import dump_papers
 
 arxiv_field_mapper = {
     'published': 'date',

--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -4,8 +4,9 @@ import os
 from datetime import datetime
 
 import pkg_resources
-from paperscraper.xrxiv.xrxiv_api import BioRxivApi
 from tqdm import tqdm
+
+from ..xrxiv.xrxiv_api import BioRxivApi
 
 today = datetime.today().strftime('%Y-%m-%d')
 save_path = os.path.join(

--- a/paperscraper/get_dumps/chemrxiv.py
+++ b/paperscraper/get_dumps/chemrxiv.py
@@ -3,7 +3,8 @@ import os
 from datetime import datetime
 
 import pkg_resources
-from paperscraper.get_dumps.utils.chemrxiv import ChemrxivAPI, download_full, parse_dump
+
+from .utils.chemrxiv import ChemrxivAPI, download_full, parse_dump
 
 today = datetime.today().strftime('%Y-%m-%d')
 save_folder = pkg_resources.resource_filename('paperscraper', 'server_dumps')

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -4,8 +4,9 @@ import os
 from datetime import datetime
 
 import pkg_resources
-from paperscraper.xrxiv.xrxiv_api import MedRxivApi
 from tqdm import tqdm
+
+from ..xrxiv.xrxiv_api import MedRxivApi
 
 today = datetime.today().strftime('%Y-%m-%d')
 save_folder = pkg_resources.resource_filename('paperscraper', 'server_dumps')

--- a/paperscraper/load_dumps.py
+++ b/paperscraper/load_dumps.py
@@ -5,9 +5,9 @@ import sys
 
 import pkg_resources
 
-from paperscraper.arxiv import get_and_dump_arxiv_papers
-from paperscraper.pubmed import get_and_dump_pubmed_papers
-from paperscraper.xrxiv.xrxiv_query import XRXivQuery
+from .arxiv import get_and_dump_arxiv_papers
+from .pubmed import get_and_dump_pubmed_papers
+from .xrxiv.xrxiv_query import XRXivQuery
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/paperscraper/pubmed/pubmed.py
+++ b/paperscraper/pubmed/pubmed.py
@@ -3,8 +3,8 @@ from typing import List, Union
 
 from pymed import PubMed
 
-from paperscraper.pubmed.utils import get_query_from_keywords_and_date
-from paperscraper.utils import dump_papers
+from .utils import get_query_from_keywords_and_date
+from ..utils import dump_papers
 
 PUBMED = PubMed(tool="MyTool", email="abc@def.gh")
 

--- a/paperscraper/scholar/scholar.py
+++ b/paperscraper/scholar/scholar.py
@@ -2,8 +2,9 @@ import logging
 import sys
 from typing import List
 
-from paperscraper.utils import dump_papers
 from scholarly import scholarly
+
+from ..utils import dump_papers
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Adding missing `__init__.py` in paperscraper/get_dumps/utils.

Moving to PEP-compliant relative imports.

This addresses #4 

Signed-off-by: Matteo Manica <drugilsberg@gmail.com>