### PR TITLE
pin: arxiv dependency to <1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ get_and_dump_pubmed_papers(query, output_filepath='covid19_ai_imaging.jsonl')
 * Scrape papers from arXiv:
 
 ```py
-from paperscraper.pubmed import get_and_dump_arxiv_papers
+from paperscraper.arxiv import get_and_dump_arxiv_papers
 
 get_and_dump_arxiv_papers(query, output_filepath='covid19_ai_imaging.jsonl')
 ```

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/PhosphorylatedRabbits/paperscraper',
     license='MIT',
     install_requires=[
-        'arxiv',
+        'arxiv==0.5.3',
         'pymed',
         'pandas',
         'requests',


### PR DESCRIPTION
arxiv was updated, paperscraper does not reflect this, so I'm pinning the version in the setup