### PR TITLE
Upgrade `arxiv` dependency to 1.4.2

### DIFF
--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the module."""
 __name__ = 'paperscraper'
-__version__ = '0.0.4'
+__version__ = '0.1.0'
 
 import logging
 import os

--- a/paperscraper/arxiv/arxiv.py
+++ b/paperscraper/arxiv/arxiv.py
@@ -40,7 +40,7 @@ def get_arxiv_papers(
         list of dicts. One dict per paper.
 
     """
-    results = arxiv.Search(query=query, max_results=max_results, *args, **kwargs).get()
+    results = arxiv.Search(query=query, max_results=max_results, *args, **kwargs).results()
     if kwargs.get('iterative', False):
         results = list(results)
     processed = [

--- a/paperscraper/arxiv/arxiv.py
+++ b/paperscraper/arxiv/arxiv.py
@@ -1,9 +1,9 @@
-from datetime import datetime
 from typing import List, Union
 
 import arxiv
-from .utils import get_query_from_keywords
+
 from ..utils import dump_papers
+from .utils import get_query_from_keywords
 
 arxiv_field_mapper = {
     'published': 'date',
@@ -34,15 +34,13 @@ def get_arxiv_papers(
         query (str): Query to arxiv API. Needs to match the arxiv API notation.
         fields (list[str]): List of strings with fields to keep in output.
         max_results (int): Maximal number of results, defaults to 99999.
-        *args, **kwargs are additional arguments for arxiv.query
+        *args, **kwargs are additional arguments for arxiv.Search()
 
     Returns:
         list of dicts. One dict per paper.
 
     """
     results = arxiv.Search(query=query, max_results=max_results, *args, **kwargs).results()
-    if kwargs.get('iterative', False):
-        results = list(results)
     processed = [
         {
             arxiv_field_mapper.get(key, key): process_fields.get(
@@ -74,6 +72,7 @@ def get_and_dump_arxiv_papers(
         fields (List, optional): List of strings with fields to keep in output.
             Defaults to ['title', 'authors', 'date', 'abstract',
             'journal', 'doi'].
+        *args, **kwargs are additional arguments for arxiv.Search()
     """
     # Translate keywords into query.
     query = get_query_from_keywords(keywords)

--- a/paperscraper/arxiv/arxiv.py
+++ b/paperscraper/arxiv/arxiv.py
@@ -11,9 +11,10 @@ arxiv_field_mapper = {
     'summary': 'abstract',
 }
 
-# Authors and journal fields need specific processing
+# Authors, date, and journal fields need specific processing
 process_fields = {
     'authors': lambda authors: ', '.join([a.name for a in authors]),
+    'date': lambda date: date.strftime('%Y-%m-%d'),
     'journal': lambda j: j if j is not None else '',
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arxiv==0.5.3
+arxiv==1.4.1
 pymed==0.8.9
 pandas>=1.0.4
 requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arxiv>=1.4.1
+arxiv>=1.4.2
 pymed==0.8.9
 pandas>=1.0.4
 requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arxiv==1.4.1
+arxiv>=1.4.1
 pymed==0.8.9
 pandas>=1.0.4
 requests==2.24.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/PhosphorylatedRabbits/paperscraper',
     license='MIT',
     install_requires=[
-        'arxiv==0.5.3',
+        'arxiv>=1.4.1',
         'pymed',
         'pandas',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/PhosphorylatedRabbits/paperscraper',
     license='MIT',
     install_requires=[
-        'arxiv>=1.4.1',
+        'arxiv>=1.4.2',
         'pymed',
         'pandas',
         'requests',


### PR DESCRIPTION
## Changes

Fix #8 : Pins `arxiv==1.4.1`. Uses `vars()` to convert `arxiv.Result`s to `dict`s for processing.

Updates `arxiv_field_mapper` and `process_fields` accordingly:

+ `(arxiv.Result).journal_reference` is now `(arxiv.Result).journal_ref`.
+ `(arxiv.Result).date` is now a `datetime`; it needs formatting, but not conversion.
+ `(arxiv.Result).authors` is now a list of `arxiv.Author` objects; these are converted to a string.

### Testing

I confirmed that the default fields are processed appropriately for an example paper. The processed dict returned by `get_arxiv_papers`:

```python
{
  'date': '2018-02-20',
  'title': 'Fault Detection Effectiveness of Source Test Case Generation Strategies for Metamorphic Testing',
  'authors': 'Prashanta Saha, Upulee Kanewala',
  'abstract': 'Metamorphic testing is a well known approach to tackle the oracle problem in\nsoftware testing. This technique requires the use of source test cases that\nserve as seeds for the generation of follow-up test cases. Systematic design of\ntest cases is crucial for the test quality. Thus, source test case generation\nstrategy can make a big impact on the fault detection effectiveness of\nmetamorphic testing. Most of the previous studies on metamorphic testing have\nused either random test data or existing test cases as source test cases. There\nhas been limited research done on systematic source test case generation for\nmetamorphic testing. This paper provides a comprehensive evaluation on the\nimpact of source test case generation techniques on the fault finding\neffectiveness of metamorphic testing. We evaluated the effectiveness of line\ncoverage, branch coverage, weak mutation and random test generation strategies\nfor source test case generation. The experiments are conducted with 77 methods\nfrom 4 open source code repositories. Our results show that by systematically\ncreating source test cases, we can significantly increase the fault finding\neffectiveness of metamorphic testing. Further, in this paper we introduce a\nsimple metamorphic testing tool called "METtester" that we use to conduct\nmetamorphic testing on these methods.',
  'journal': '',
  'doi': None
}
```

I also did some light integration testing:

```pycon
>>> from paperscraper.arxiv import get_and_dump_arxiv_papers
>>> query=["relativistic", "strophotron"]
>>> get_and_dump_arxiv_papers(query, output_filepath='rs.jsonl')
```

Which yields the following file:

```
{'date': '2016-12-13', 'title': 'Electron Dynamics in Relativistic Strophotron', 'authors': 'Karen Ivanyan', 'abstract': 'Relativistic strophotron is a system in which fast electrons move along a\npotential trough produced by quadrupole electric lenses. Equations of motion in\nthe strophotron field are investigated and electron trajectories are found. It\nis shown, that electrons are harmonically oscillating in transverse direction\nand do complex motion in longitudinal direction.', 'journal': '', 'doi': None}
{'date': '2016-12-22', 'title': 'Spontaneous Radiation in Relativistic Strophotron', 'authors': 'I. V. Dovgan', 'abstract': 'Spectral intensity of spontaneous radiation is calculated in relativistic\nstrophotron. It is shown, that it in the strophotron is given by a\nsuperposition of contributions from emission at different (odd) harmonics of\nthe main resonance frequency . The main resonance frequency is shown to depend\non the initial conditions of the electron, and in particular on its initial\ntransversal coordinate .', 'journal': '', 'doi': None}
{'date': '2021-08-08', 'title': 'An electron as a wave packet in the relativistic strophotron fel', 'authors': 'M. Hnatic, P. Kopcansky, K. B. Oganesyan', 'abstract': 'We study the initial distribution of electrons in relativistic strophotron\nFEL over vibrational levels determined by the expansion coefficients. We show\nthe quantity of the vibrational level can be expressed in terms of the initial\nparameters of the electron beam.', 'journal': '', 'doi': None}
{'date': '2016-12-30', 'title': 'The emitted energy in RS', 'authors': 'I. V. Dovgan', 'abstract': 'The emitted energy of electrons is calculated in relativistic strophotron. It\nis shown, that it is superposition of amplification at harmonics of main\nresonance frequency of the system.', 'journal': '', 'doi': None}
{'date': '2016-12-15', 'title': 'Quadrupole lenses scheme for RS FEL', 'authors': 'K. V. Ivanyan', 'abstract': 'The scheme with quadrupole lenses is presented for realization relativistic\nstrophotron type Free electron laser. Equations of motion are solved and\ntrajectories are found. It is shown, that movement of electrons in presented\nscheme is stable in both transverse directions.', 'journal': '', 'doi': None}
{'date': '2017-01-07', 'title': 'The Gain in RS', 'authors': 'I. V. Dovgan', 'abstract': 'The calculated linear gain in relativistic strophotron is averaged over\nelectron distribution. It is shown, that after averaging resonance peaks remain\nin amplification spectrum. The nonresonant background gives only negligibly\nsmall contribution to the gain.', 'journal': '', 'doi': None}
{'date': '2016-12-27', 'title': 'Averaging of Spontaneous Radiation in Relativistic Strophotron', 'authors': 'I. V. Dovgan', 'abstract': 'The main resonance frequency is shown to depend on the initial conditions of\nthe electron, and in particular on its initial transversal coordinate xo. This\ndependence is shown to give rise to a very strong inhomogeneous broadening of\nthe spectral lines. The broadening can become large enough for the spectral\nlines to overlap with each other. The spectral intensity of a spontaneous\nemission is averaged over xo. The averaged spectral intensity is shown to have\nonly a very weakly expressed resonance structure.', 'journal': '', 'doi': None}
```

## Notes

**May break non-default usage of `get_arxiv_papers`:** available field names may have changed, and search/client options may have changed.

`vars(r: arxiv.Result)` exposes the following fields:

```pycon
>>> vars(paper).keys()
dict_keys(['entry_id', 'updated', 'published', 'title', 'authors', 'summary', 'comment', 'journal_ref', 'doi', 'primary_category', 'categories', 'links', 'pdf_url', '_raw'])
```

A few more things to consider in review:

+ `arxiv>=1.0.0` specifies search and client options separately. Perhaps these should be separate parameters to `get_and_dump_arxiv_papers`; happy to chat about how the package can enable that (e.g. by specifying some `arxiv.ClientOptions`/`arxiv.SearchOptions` types).
    This PR uses the default client.

+ This change to `process_fields` converts `(arxiv.Result).authors` into a single string of names (see [example above](#Testing)).
    A list of strings may be more appropriate––happy to make that change!

+ I don't think the `if kwargs.get('iterative', False)` condition is useful: it makes this function strictly less efficient.

Hope this is helpful! I spotted the reference to #8 on https://github.com/lukasschwab/arxiv.py/issues/43.