### PR TITLE
fix: preprint['id'] should be preprint['item']['id']

### DIFF
--- a/paperscraper/get_dumps/utils/chemrxiv/utils.py
+++ b/paperscraper/get_dumps/utils/chemrxiv/utils.py
@@ -133,11 +133,11 @@ def download_full(save_dir: str, api: Optional[ChemrxivAPI] = None) -> None:
     os.makedirs(save_dir, exist_ok=True)
     for preprint in tqdm(api.all_preprints()):
 
-        path = os.path.join(save_dir, f"{preprint['id']}.json")
+        path = os.path.join(save_dir, f"{preprint['item']['id']}.json")
         if os.path.exists(path):
             continue
-        preprint_id = preprint["id"]
         preprint = preprint["item"]
+        preprint_id = preprint["id"]
         try:
             preprint = api.preprint(preprint_id)
         except HTTPError:


### PR DESCRIPTION
Hi @jannisborn ,
I have tested the code from v0.2.2 and found that you changed the `preprint` variable in the last commit, and then there would be a `KeyError: ['id ']` error when I import the chemrxiv() method. Becaus the original code was like:
```
preprint = preprint["item"]
preprint_id = preprint["id"]
```
then the variable `preprint` actually becomes `preprint['item']`, so the second variable `preprint_id` actually means`preprint["item"]['id']`, but in the last version, it is not like that in line 136.

Am I right?

I will start a new pull request for your convenient, but maybe you would like to make the fix yourself along with other fixes or features, it's up to you. :)