### PR TITLE
Adding a time range functionality to extract records from biorxiv and medrxiv.

### DIFF
--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -2,6 +2,7 @@
 import json
 import os
 from datetime import datetime
+from typing import Optional
 
 import pkg_resources
 from tqdm import tqdm
@@ -15,7 +16,10 @@ save_path = os.path.join(
 )
 
 
-def biorxiv(save_path: str = save_path):
+def biorxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path):
     """Fetches all papers from biorxiv until current date, stores them in jsonl
     format in save_path.
 
@@ -28,7 +32,7 @@ def biorxiv(save_path: str = save_path):
 
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers())):
+        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -20,12 +20,18 @@ def biorxiv(
         begin_date: Optional[str] = None,
         end_date: Optional[str] = None,
         save_path: str = save_path):
-    """Fetches all papers from biorxiv until current date, stores them in jsonl
-    format in save_path.
+    """Fetches papers from biorxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, papers will be fetched from biorxiv 
+    from the launch date of biorxiv until the current date. The fetched papers will be 
+    stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
     """
     # create API client
     api = BioRxivApi()

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -2,6 +2,7 @@
 import json
 import os
 from datetime import datetime
+from typing import Optional
 
 import pkg_resources
 from tqdm import tqdm
@@ -13,7 +14,10 @@ save_folder = pkg_resources.resource_filename("paperscraper", "server_dumps")
 save_path = os.path.join(save_folder, f"medrxiv_{today}.jsonl")
 
 
-def medrxiv(save_path: str = save_path):
+def medrxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path):
     """Fetches all papers from medrxiv until current date, stores them in jsonl
     format in save_path.
 
@@ -25,7 +29,7 @@ def medrxiv(save_path: str = save_path):
     api = MedRxivApi()
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers())):
+        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -18,12 +18,18 @@ def medrxiv(
         begin_date: Optional[str] = None,
         end_date: Optional[str] = None,
         save_path: str = save_path):
-    """Fetches all papers from medrxiv until current date, stores them in jsonl
-    format in save_path.
+    """Fetches papers from medrxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, then papers will be fetched from 
+    medrxiv starting from the launch date of medrxiv until current date. The fetched 
+    papers will be stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
     """
     # create API client
     api = MedRxivApi()


### PR DESCRIPTION
During the bulk extraction of the BioArxiv and MedArxiv articles using biorxiv and medrxiv functions. The current code used to always start from the launch_date of the respective server till today's date. If the script fails in between due to the connection error, then re-executing the script results in overwriting the existing file with the records from the launch_date instead of starting to extract from the last checkpoint. Now with this pull request, a time range functionality is added in the biorxiv and medrxiv with the begin_date and end_date optional parameters. So if the user wants to extract articles for a specific time frame, then with these changes, they can extract the articles for the specific time frame. Thus, every time the function is executed if the user specifies the begin_date and end_date then it will extract for a specific time frame otherwise it will take launch_date and today_date as the begin and end date. Thus, functionality is added to provide a begin_date and end_date parameter to the biorxiv and medrxvi scripts for article extraction.