### PR TITLE
Adding a time range functionality to extract records from chemrxiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,14 @@ medrxiv()  #  Takes ~30min and should result in ~35 MB file
 biorxiv()  # Takes ~1h and should result in ~350 MB file
 chemrxiv()  #  Takes ~45min and should result in ~20 MB file
 ```
-
 *NOTE*: Once the dumps are stored, please make sure to restart the python interpreter
 so that the changes take effect. 
+
+Since v0.2.5 `paperscraper` also allows to scrape {med/bio/chem}rxiv for specific dates! Thanks to [@achouhan93 ](https://github.com/achouhan93 ) for contributions!
+```py
+medrxiv(begin_date="2023-04-01", end_date="2023-04-08")
+```
+But watch out. The resulting `.jsonl` file will be labelled according to the current date and all your subsequent searches will be based on this file **only**. If you use this option you might want to keep an eye on the source files (`paperscraper/server_dumps/*jsonl`) to ensure they contain the paper metadata for all papers you're interested in.
 
 ## Examples
 

--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the module."""
 __name__ = "paperscraper"
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 import logging
 import os

--- a/paperscraper/arxiv/arxiv.py
+++ b/paperscraper/arxiv/arxiv.py
@@ -1,8 +1,7 @@
 from typing import Dict, List, Union
 
-import pandas as pd
-
 import arxiv
+import pandas as pd
 
 from ..utils import dump_papers
 from .utils import get_query_from_keywords

--- a/paperscraper/get_dumps/__init__.py
+++ b/paperscraper/get_dumps/__init__.py
@@ -1,3 +1,3 @@
 from .biorxiv import biorxiv  # noqa
-from .medrxiv import medrxiv  # noqa
 from .chemrxiv import chemrxiv  # noqa
+from .medrxiv import medrxiv  # noqa

--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -17,18 +17,19 @@ save_path = os.path.join(
 
 
 def biorxiv(
-        begin_date: Optional[str] = None,
-        end_date: Optional[str] = None,
-        save_path: str = save_path):
-    """Fetches papers from biorxiv based on time range, i.e., begin_date and end_date. 
-    If the begin_date and end_date are not provided, papers will be fetched from biorxiv 
-    from the launch date of biorxiv until the current date. The fetched papers will be 
+    begin_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    save_path: str = save_path,
+):
+    """Fetches papers from biorxiv based on time range, i.e., begin_date and end_date.
+    If the begin_date and end_date are not provided, papers will be fetched from biorxiv
+    from the launch date of biorxiv until the current date. The fetched papers will be
     stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
-        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD.
             Defaults to None.
         end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
             Defaults to None.
@@ -38,7 +39,9 @@ def biorxiv(
 
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
+        for index, paper in enumerate(
+            tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))
+        ):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -2,6 +2,7 @@
 import json
 import os
 from datetime import datetime
+from typing import Optional
 
 import pkg_resources
 from tqdm import tqdm
@@ -15,7 +16,10 @@ save_path = os.path.join(
 )
 
 
-def biorxiv(save_path: str = save_path):
+def biorxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path):
     """Fetches all papers from biorxiv until current date, stores them in jsonl
     format in save_path.
 
@@ -28,7 +32,7 @@ def biorxiv(save_path: str = save_path):
 
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers())):
+        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -20,12 +20,18 @@ def biorxiv(
         begin_date: Optional[str] = None,
         end_date: Optional[str] = None,
         save_path: str = save_path):
-    """Fetches all papers from biorxiv until current date, stores them in jsonl
-    format in save_path.
+    """Fetches papers from biorxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, papers will be fetched from biorxiv 
+    from the launch date of biorxiv until the current date. The fetched papers will be 
+    stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
     """
     # create API client
     api = BioRxivApi()

--- a/paperscraper/get_dumps/chemrxiv.py
+++ b/paperscraper/get_dumps/chemrxiv.py
@@ -4,6 +4,8 @@ import os
 import sys
 from datetime import datetime
 
+from typing import Optional
+
 import pkg_resources
 
 from .utils.chemrxiv import ChemrxivAPI, download_full, parse_dump
@@ -16,17 +18,26 @@ save_folder = pkg_resources.resource_filename("paperscraper", "server_dumps")
 save_path = os.path.join(save_folder, f"chemrxiv_{today}.jsonl")
 
 
-def chemrxiv(save_path: str = save_path) -> None:
-    """Fetches all papers from biorxiv until current date, stores them in jsonl
-    format in save_path.
+def chemrxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path) -> None:
+    """Fetches papers from bichemrxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, papers will be fetched from chemrxiv 
+    from the launch date of chemrxiv until the current date. The fetched papers will be 
+    stored in jsonl format in save_path.
 
     Args:
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
     """
 
     # create API client
-    api = ChemrxivAPI()
+    api = ChemrxivAPI(begin_date, end_date)
     # Download the data
     download_full(save_folder, api)
     # Convert to JSONL format.

--- a/paperscraper/get_dumps/chemrxiv.py
+++ b/paperscraper/get_dumps/chemrxiv.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 from datetime import datetime
-
 from typing import Optional
 
 import pkg_resources
@@ -19,16 +18,17 @@ save_path = os.path.join(save_folder, f"chemrxiv_{today}.jsonl")
 
 
 def chemrxiv(
-        begin_date: Optional[str] = None,
-        end_date: Optional[str] = None,
-        save_path: str = save_path) -> None:
-    """Fetches papers from bichemrxiv based on time range, i.e., begin_date and end_date. 
-    If the begin_date and end_date are not provided, papers will be fetched from chemrxiv 
-    from the launch date of chemrxiv until the current date. The fetched papers will be 
+    begin_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    save_path: str = save_path,
+) -> None:
+    """Fetches papers from bichemrxiv based on time range, i.e., begin_date and end_date.
+    If the begin_date and end_date are not provided, papers will be fetched from chemrxiv
+    from the launch date of chemrxiv until the current date. The fetched papers will be
     stored in jsonl format in save_path.
 
     Args:
-        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD.
             Defaults to None.
         end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
             Defaults to None.

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -2,6 +2,7 @@
 import json
 import os
 from datetime import datetime
+from typing import Optional
 
 import pkg_resources
 from tqdm import tqdm
@@ -13,7 +14,10 @@ save_folder = pkg_resources.resource_filename("paperscraper", "server_dumps")
 save_path = os.path.join(save_folder, f"medrxiv_{today}.jsonl")
 
 
-def medrxiv(save_path: str = save_path):
+def medrxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path):
     """Fetches all papers from medrxiv until current date, stores them in jsonl
     format in save_path.
 
@@ -25,7 +29,7 @@ def medrxiv(save_path: str = save_path):
     api = MedRxivApi()
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers())):
+        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -18,12 +18,18 @@ def medrxiv(
         begin_date: Optional[str] = None,
         end_date: Optional[str] = None,
         save_path: str = save_path):
-    """Fetches all papers from medrxiv until current date, stores them in jsonl
-    format in save_path.
+    """Fetches papers from medrxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, then papers will be fetched from 
+    medrxiv starting from the launch date of medrxiv until current date. The fetched 
+    papers will be stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
     """
     # create API client
     api = MedRxivApi()

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -15,18 +15,19 @@ save_path = os.path.join(save_folder, f"medrxiv_{today}.jsonl")
 
 
 def medrxiv(
-        begin_date: Optional[str] = None,
-        end_date: Optional[str] = None,
-        save_path: str = save_path):
-    """Fetches papers from medrxiv based on time range, i.e., begin_date and end_date. 
-    If the begin_date and end_date are not provided, then papers will be fetched from 
-    medrxiv starting from the launch date of medrxiv until current date. The fetched 
+    begin_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    save_path: str = save_path,
+):
+    """Fetches papers from medrxiv based on time range, i.e., begin_date and end_date.
+    If the begin_date and end_date are not provided, then papers will be fetched from
+    medrxiv starting from the launch date of medrxiv until current date. The fetched
     papers will be stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
-        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD.
             Defaults to None.
         end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
             Defaults to None.
@@ -35,7 +36,9 @@ def medrxiv(
     api = MedRxivApi()
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
+        for index, paper in enumerate(
+            tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))
+        ):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/utils/chemrxiv/__init__.py
+++ b/paperscraper/get_dumps/utils/chemrxiv/__init__.py
@@ -1,2 +1,2 @@
-from .utils import *  # noqa
 from .chemrxiv_api import ChemrxivAPI  # noqa
+from .utils import *  # noqa

--- a/paperscraper/get_dumps/utils/chemrxiv/chemrxiv_api.py
+++ b/paperscraper/get_dumps/utils/chemrxiv/chemrxiv_api.py
@@ -1,11 +1,17 @@
+import logging
 import os
-from typing import Optional, Dict
-from datetime import datetime 
+import sys
+from datetime import datetime
+from typing import Dict, Optional
 
 import requests
 
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
 now_datetime = datetime.now()
 launch_dates = {"chemrxiv": "2017-01-01"}
+
 
 class ChemrxivAPI:
     """Handle OpenEngage API requests, using access.
@@ -14,15 +20,17 @@ class ChemrxivAPI:
 
     base = "https://chemrxiv.org/engage/chemrxiv/public-api/v1"
 
-    def __init__(self,
-                 begin_date: Optional[str] = None,
-                 end_date: Optional[str] = None,
-                 page_size: Optional[int] = None):
+    def __init__(
+        self,
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        page_size: Optional[int] = None,
+    ):
         """
         Initialize API class.
 
         Args:
-            begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD.
                 Defaults to None.
             end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
                 Defaults to None.
@@ -30,9 +38,9 @@ class ChemrxivAPI:
         """
 
         self.page_size = page_size or 50
-        
+
         # Begin Date and End Date of the search
-        launch_date = launch_dates['chemrxiv']
+        launch_date = launch_dates["chemrxiv"]
         launch_datetime = datetime.fromisoformat(launch_date)
 
         if begin_date:
@@ -51,7 +59,6 @@ class ChemrxivAPI:
                 self.end_date = end_date
         else:
             self.end_date = now_datetime.strftime("%Y-%m-%d")
-        
 
     def request(self, url, method, params=None):
         """Send an API request to open Engage."""
@@ -76,11 +83,14 @@ class ChemrxivAPI:
 
         page = 0
         while True:
-            params.update({
-                "limit": self.page_size, 
-                "skip": page * self.page_size,
-                "searchDateFrom": self.begin_date,
-                "searchDateTo": self.end_date})
+            params.update(
+                {
+                    "limit": self.page_size,
+                    "skip": page * self.page_size,
+                    "searchDateFrom": self.begin_date,
+                    "searchDateTo": self.end_date,
+                }
+            )
             r = self.request(os.path.join(self.base, query), method, params=params)
             if r.status_code == 400:
                 raise ValueError(r.json()["message"])

--- a/paperscraper/get_dumps/utils/chemrxiv/chemrxiv_api.py
+++ b/paperscraper/get_dumps/utils/chemrxiv/chemrxiv_api.py
@@ -1,8 +1,11 @@
 import os
 from typing import Optional, Dict
+from datetime import datetime 
 
 import requests
 
+now_datetime = datetime.now()
+launch_dates = {"chemrxiv": "2017-01-01"}
 
 class ChemrxivAPI:
     """Handle OpenEngage API requests, using access.
@@ -11,9 +14,44 @@ class ChemrxivAPI:
 
     base = "https://chemrxiv.org/engage/chemrxiv/public-api/v1"
 
-    def __init__(self, page_size: Optional[int] = None):
+    def __init__(self,
+                 begin_date: Optional[str] = None,
+                 end_date: Optional[str] = None,
+                 page_size: Optional[int] = None):
+        """
+        Initialize API class.
+
+        Args:
+            begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+                Defaults to None.
+            end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+                Defaults to None.
+            page_size (int, optional): The batch size used to fetch the records from chemrxiv.
+        """
 
         self.page_size = page_size or 50
+        
+        # Begin Date and End Date of the search
+        launch_date = launch_dates['chemrxiv']
+        launch_datetime = datetime.fromisoformat(launch_date)
+
+        if begin_date:
+            begin_datetime = datetime.fromisoformat(begin_date)
+            if begin_datetime < launch_datetime:
+                self.begin_date = launch_date
+            else:
+                self.begin_date = begin_date
+        else:
+            self.begin_date = launch_date
+        if end_date:
+            end_datetime = datetime.fromisoformat(end_date)
+            if end_datetime > now_datetime:
+                self.end_date = now_datetime.strftime("%Y-%m-%d")
+            else:
+                self.end_date = end_date
+        else:
+            self.end_date = now_datetime.strftime("%Y-%m-%d")
+        
 
     def request(self, url, method, params=None):
         """Send an API request to open Engage."""
@@ -38,7 +76,11 @@ class ChemrxivAPI:
 
         page = 0
         while True:
-            params.update({"limit": self.page_size, "skip": page * self.page_size})
+            params.update({
+                "limit": self.page_size, 
+                "skip": page * self.page_size,
+                "searchDateFrom": self.begin_date,
+                "searchDateTo": self.end_date})
             r = self.request(os.path.join(self.base, query), method, params=params)
             if r.status_code == 400:
                 raise ValueError(r.json()["message"])

--- a/paperscraper/get_dumps/utils/chemrxiv/chemrxiv_api.py
+++ b/paperscraper/get_dumps/utils/chemrxiv/chemrxiv_api.py
@@ -47,6 +47,9 @@ class ChemrxivAPI:
             begin_datetime = datetime.fromisoformat(begin_date)
             if begin_datetime < launch_datetime:
                 self.begin_date = launch_date
+                logger.warning(
+                    f"Begin date {begin_date} is before chemrxiv launch date. Will use {launch_date} instead."
+                )
             else:
                 self.begin_date = begin_date
         else:
@@ -54,6 +57,9 @@ class ChemrxivAPI:
         if end_date:
             end_datetime = datetime.fromisoformat(end_date)
             if end_datetime > now_datetime:
+                logger.warning(
+                    f"End date {end_date} is in the future. Will use {now_datetime} instead."
+                )
                 self.end_date = now_datetime.strftime("%Y-%m-%d")
             else:
                 self.end_date = end_date

--- a/paperscraper/get_dumps/utils/chemrxiv/utils.py
+++ b/paperscraper/get_dumps/utils/chemrxiv/utils.py
@@ -28,9 +28,7 @@ def get_author(author_list: List[Dict]) -> str:
         str: ;-concatenated author list.
     """
 
-    return "; ".join(
-        [" ".join([a["firstName"], a["lastName"]]) for a in author_list]
-    )
+    return "; ".join([" ".join([a["firstName"], a["lastName"]]) for a in author_list])
 
 
 def get_categories(category_list: List[Dict]) -> str:
@@ -143,7 +141,7 @@ def download_full(save_dir: str, api: Optional[ChemrxivAPI] = None) -> None:
         except HTTPError:
             logger.warning(f"HTTP API Client error for ID: {preprint_id}")
         except SSLError:
-            logger.warning(f'SSLError for ID: {preprint_id}')
+            logger.warning(f"SSLError for ID: {preprint_id}")
 
         with open(path, "w") as file:
             json.dump(preprint, file, indent=2)

--- a/paperscraper/postprocessing.py
+++ b/paperscraper/postprocessing.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd

--- a/paperscraper/pubmed/utils.py
+++ b/paperscraper/pubmed/utils.py
@@ -1,6 +1,7 @@
-from pymed.article import PubMedArticle
 import warnings
 from typing import List, Union
+
+from pymed.article import PubMedArticle
 
 finalize_disjunction = lambda x: "(" + x[:-4] + ") AND "
 finalize_conjunction = lambda x: x[:-5]

--- a/paperscraper/xrxiv/xrxiv_api.py
+++ b/paperscraper/xrxiv/xrxiv_api.py
@@ -1,8 +1,8 @@
 """API for bioRxiv and medRXiv."""
-import requests
 from datetime import datetime
-from typing import Optional, List, Generator
+from typing import Generator, List, Optional
 
+import requests
 
 launch_dates = {"biorxiv": "2013-01-01", "medrxiv": "2019-06-01"}
 


### PR DESCRIPTION
Hi @jannisborn,
During the bulk extraction of the chemrxiv articles using chemrxiv functions. The current code used was not using a time range functionality for extraction. With this pull request, a time range functionality is added in the chemrxiv with the begin_date and end_date optional parameters. So if the user wants to extract articles for a specific time frame, then with these changes, they can extract the articles for the specific time frame. Thus, every time the function is executed, if the user specifies the begin_date and end_date, it will extract for a specific time frame; otherwise, it will take launch_date and today_date as the begin and end date. Thus, functionality is added to provide a begin_date and end_date parameter to the chemrxiv scripts for article extraction. Please consider this pull request.