### PR TITLE
Save DOIs from arxiv papers

### DIFF
--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the module."""
 __name__ = "paperscraper"
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 import logging
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arxiv>=1.4.2
+arxiv>=1.4.7
 pymed==0.8.9
 pandas>=1.0.4
 requests==2.24.0


### PR DESCRIPTION
Fixes #26 

--> When querying `arxiv` the DOIs are now also processed and stored (they used to be None/nill since arxiv did not assign DOIs in the past)

ARXIV website states:
_An author can determine their article’s DOI by using the DOI prefix https://doi.org/10.48550/ followed by the arXiv ID (replacing the colon with a period). For example, the arXiv ID [arXiv:2202.01037](https://arxiv.org/abs/2202.01037) will translate to the DOI link https://doi.org/10.48550/arXiv.2202.01037_

This is fantastic because it implies that all existing/old papers that were originally not assigned DOIs can now retrospectively be assigned arxiv-dois


**This enables to save PDFs from any arxiv search:**

```py
from paperscraper.arxiv import get_and_dump_arxiv_papers
from paperscraper.pdf import save_pdf_from_dump

prompt = ['prompt engineering llm', 'prompt injection llm']
ai = ['Artificial intelligence', 'Large Language Models', 'OpenAI','LLM']
mi = ['ChatGPT']
query = [prompt, ai, mi]

get_and_dump_arxiv_papers(query, output_filepath='pro_inject.jsonl')
print('Finished processing & saving metadata, scraping PDFs now...')
save_pdf_from_dump('pro_inject.jsonl, pdf_path='.', key_to_save='doi')
```

Thanks for raising this @mwarqee

