### PR TITLE
Hotfix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,40 @@
 ---
-name: build
-on: [push]
+name: build-and-test
+on: [push, release]
 jobs:
-  build:
+  test-source-install:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install -e .
-          python -c "import paperscraper"
-      - name: Run test suite
+      - name: Install package from source
+        run: pip install -e .
+      - name: Test package from source
         run: |
+          python -c "import paperscraper"
           python -m pytest -sv paperscraper
+  verify-current-pypi-install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install package from PyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install paperscraper
+      - name: Test package from PyPI
+        run: |
+          python -c "import paperscraper"
+          python -m pytest -sv paperscraper
+
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Test package from PyPI
         run: |
           python -c "import paperscraper"
-          python -m pytest -sv paperscraper
+          python -c "import paperscraper.pdf"
+          python -c "import paperscraper.arxiv"
+          python -c "import paperscraper.scholar"
+          python -c "import paperscraper.plotting"
+          python -c "import paperscraper.pubmed"
+          python -c "import paperscraper.get_dumps"
+          python -c "import paperscraper.server_dumps"
+          python -c "import paperscraper.test"
+          python -c "import paperscraper.impact"
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           python -c "import paperscraper.pubmed"
           python -c "import paperscraper.get_dumps"
           python -c "import paperscraper.server_dumps"
-          python -c "import paperscraper.test"
+          python -c "import paperscraper.tests"
           python -c "import paperscraper.impact"
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install paperscraper
+          pip install pytest
       - name: Test package from PyPI
         run: |
           python -c "import paperscraper"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          # pip install -r requirements.txt # not recommended
           pip install setuptools wheel twine
       - name: Build and publish
         env:

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -33,8 +33,12 @@ jobs:
 
     - name: Install from built distribution
       run: |
-        pip install dist/*
-
+        # Check if a wheel exists, and install it if available, otherwise install the source distribution
+        if [ -e dist/*.whl ]; then
+          pip install dist/*.whl
+        else
+          pip install dist/*
+        fi
     - name: Run tests
       run: |
         python -m pytest paperscraper

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -1,0 +1,36 @@
+---
+name: PyPI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  verify-master-for-potential-pypi-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Install from built distribution
+      run: |
+        pip install dist/*
+
+    - name: Run tests
+      run: |
+        python -m pytest paperscraper

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -2,16 +2,20 @@
 name: PyPI
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - '*'
 
 jobs:
-  verify-master-for-potential-pypi-release:
+  verify-for-potential-pypi-release:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2

--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the module."""
 __name__ = "paperscraper"
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 import logging
 import os

--- a/paperscraper/tests/test_impactor.py
+++ b/paperscraper/tests/test_impactor.py
@@ -48,7 +48,7 @@ class TestImpactor:
         expected_results = [
             {"journal": "InfoMat", "factor": 24.798, "score": 71},
             {"journal": "Information Fusion", "factor": 17.564, "score": 71},
-            {"journal": "npj Quanfsdfsdtum Information", "factor": 10.758, "score": 95},
+            {"journal": "npj Quantum Information", "factor": 10.758, "score": 95},
         ]
 
         results = impactor.search(

--- a/paperscraper/tests/test_impactor.py
+++ b/paperscraper/tests/test_impactor.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+
 from paperscraper.impact import Impactor
 
 logging.disable(logging.INFO)
@@ -47,7 +48,7 @@ class TestImpactor:
         expected_results = [
             {"journal": "InfoMat", "factor": 24.798, "score": 71},
             {"journal": "Information Fusion", "factor": 17.564, "score": 71},
-            {"journal": "npj Quantum Information", "factor": 10.758, "score": 95},
+            {"journal": "npj Quanfsdfsdtum Information", "factor": 10.758, "score": 95},
         ]
 
         results = impactor.search(

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 """Install package."""
-import os
-from setuptools import setup
-from setuptools import find_packages
 import io
+import os
 import re
+
+from setuptools import find_packages, setup
 
 __version__ = re.search(
     r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
@@ -36,6 +36,9 @@ setup(
         "matplotlib",
         "matplotlib_venn",
         "bs4",
+        "impact-factor>=1.1.0",
+        "thefuzz",
+        "pytest",
     ],
     keywords=[
         "Academics",
@@ -47,6 +50,7 @@ setup(
         "Medrxiv",
         "Biorxiv",
         "Chemrxiv",
+        "Google Scholar",
     ],
     packages=find_packages("."),
     package_data={"paperscraper.server_dumps": ["*"]},


### PR DESCRIPTION
- Bump version to include missing dependencies in `setup.py` (prev only in `requirements.txt`)
- updated CI pipeline to test tip of master for potential pypi release (through building package similar to how `twine` does it
- updated CI pipeline to test current latest PyPI release with every push

CI now fails because the last test fails because the latest version (0.2.9) is unstable
